### PR TITLE
빌드 시 angular watch 자동 구동 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,7 @@ dependencies {
 	testCompile('org.springframework.boot:spring-boot-starter-test')
 	compileOnly "org.springframework.boot:spring-boot-configuration-processor"
 	compile 'com.auth0:java-jwt:3.4.0'
+    compile group: 'org.apache.commons', name: 'commons-exec', version: '1.3'
 }
 
 processResources {
@@ -66,9 +67,9 @@ task buildAngular(type:Exec) {
 	group = BasePlugin.BUILD_GROUP
 	// ng doesn't exist as a file in windows -> ng.cmd
 	if (System.getProperty("os.name").toUpperCase().contains("WINDOWS")){
-		commandLine "npm.cmd", "run", "build"
+		commandLine "npm.cmd", "run", "build:prod"
 	} else {
-		commandLine "npm", "run", "build"
+		commandLine "npm", "run", "build:prod"
 	}
 }
 

--- a/src/main/java/com/tram/springbootangularboard/common/WebpackWatchExecutor.java
+++ b/src/main/java/com/tram/springbootangularboard/common/WebpackWatchExecutor.java
@@ -1,0 +1,33 @@
+package com.tram.springbootangularboard.common;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.exec.CommandLine;
+import org.apache.commons.exec.DefaultExecuteResultHandler;
+import org.apache.commons.exec.DefaultExecutor;
+
+import java.io.File;
+
+@Slf4j
+public class WebpackWatchExecutor {
+    public WebpackWatchExecutor(String packageDir) {
+        try {
+            DefaultExecutor executor = new DefaultExecutor();
+            executor.setWorkingDirectory(new File(packageDir));
+
+            String line = getCommand();
+            CommandLine cmdLine = CommandLine.parse(line);
+
+            DefaultExecuteResultHandler handler = new DefaultExecuteResultHandler();
+            handler.waitFor(500);
+
+            executor.execute(cmdLine, handler);
+        } catch (Exception e) {
+            log.error("WebpackWatcher", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String getCommand() {
+        return System.getProperty("os.name").toLowerCase().contains("win") ? "npm.cmd run watch" : "npm run watch";
+    }
+}

--- a/src/main/java/com/tram/springbootangularboard/config/front/WebpackWatchConfig.java
+++ b/src/main/java/com/tram/springbootangularboard/config/front/WebpackWatchConfig.java
@@ -1,0 +1,29 @@
+package com.tram.springbootangularboard.config.front;
+
+import com.tram.springbootangularboard.common.WebpackWatchExecutor;
+import com.tram.springbootangularboard.config.properties.PackageJsonPathProperties;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+/**
+ * angular watch를 시작과 동시에 실행시키기 위한 설정
+ * local profile에서만 동작한다. dev, prod 환경에서는 동작하지 않는다.
+ */
+@Configuration
+@Profile("local")
+@EnableConfigurationProperties(PackageJsonPathProperties.class)
+public class WebpackWatchConfig {
+    @Autowired
+    private PackageJsonPathProperties packageJsonPathProperties;
+
+    //package.json 경로 property가 존재하면 빈 생성
+    @Bean
+    @ConditionalOnProperty(prefix = "npm", name = "path")
+    public WebpackWatchExecutor webpackWatchExecutor() {
+        return new WebpackWatchExecutor(packageJsonPathProperties.getPath());
+    }
+}

--- a/src/main/java/com/tram/springbootangularboard/config/properties/PackageJsonPathProperties.java
+++ b/src/main/java/com/tram/springbootangularboard/config/properties/PackageJsonPathProperties.java
@@ -1,0 +1,19 @@
+package com.tram.springbootangularboard.config.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import javax.validation.constraints.NotNull;
+
+@ConfigurationProperties(prefix = "npm")
+public class PackageJsonPathProperties {
+    @NotNull
+    private String path;
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    active: local
+    active: dev
 
 ---
 spring:
@@ -13,4 +13,27 @@ spring:
     console:
       enabled: true
 jwt:
-  secret-key: jwtlocaltest
+  secret-key: jwtlocalkey
+npm:
+  path: /Users/kyunam/Documents/workspace-intelliJ/spring-boot-angular-board/src/main/webapp
+
+---
+spring:
+  profiles: dev
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: create-drop
+  h2:
+    console:
+      enabled: true
+jwt:
+  secret-key: jwtdevlopkey
+
+---
+spring:
+  profiles: real
+
+spring:
+  profiles:
+    include: real-db

--- a/src/main/webapp/package.json
+++ b/src/main/webapp/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build --prod",
+    "build:prod": "ng build --prod",
+    "build:dev": "ng build",
+    "watch": "ng build --watch",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e"


### PR DESCRIPTION
프로젝트 빌드 시 angular watch 작동되도록 설정 추가

travis build 시 watch가 돌면서 test fail나는 문제 해결을 위해 profile dev 추가 후 default로 설정

로컬 개발 환경에서는 active profile local로 사용한다.